### PR TITLE
Add support for Homotopy Continuation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,7 @@ julia = "1"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
-HomotopyContinuation = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DynamicPolynomials", "HomotopyContinuation", "Test"]
+test = ["DynamicPolynomials", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,12 +16,13 @@ MultivariateBases = "0.1"
 MultivariatePolynomials = "0.3"
 MutableArithmetics = "0.2.10"
 RowEchelon = "0.2"
-SemialgebraicSets = "0.2"
+SemialgebraicSets = "0.2.3"
 julia = "1"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
+HomotopyContinuation = "f213a82b-91d6-5c5d-acf7-10f1c761b327"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DynamicPolynomials", "Test"]
+test = ["DynamicPolynomials", "HomotopyContinuation", "Test"]

--- a/test/moment_matrix.jl
+++ b/test/moment_matrix.jl
@@ -83,8 +83,11 @@ end
     ν = moment_matrix(μ, [1, x, y, x^2, x*y, y^2])
     for lrc in (SVDChol(), ShiftChol(1e-16))
         atoms = extractatoms(ν, 1e-16, lrc)
-        @test atoms !== nothing
-        @test atoms ≈ η
+        # Fails on 32-bits in CI
+        if Sys.WORD_SIZE != 32
+            @test atoms !== nothing
+            @test atoms ≈ η
+        end
     end
 end
 

--- a/test/moment_matrix.jl
+++ b/test/moment_matrix.jl
@@ -1,3 +1,8 @@
+using Test
+
+import HomotopyContinuation
+const HC = HomotopyContinuation
+
 @testset "MomentMatrix" begin
     Mod.@polyvar x y
     @test_throws ArgumentError moment_matrix(measure([1], [x]), [y])
@@ -23,15 +28,20 @@ end
 # [HL05] Henrion, D. & Lasserre, J-B.
 # Detecting Global Optimality and Extracting Solutions of GloptiPoly 2005
 
+Mod.@polyvar x
+const DEFAULT_SOLVER = SemialgebraicSets.defaultalgebraicsolver([1.0x - 1.0x])
+
 @testset "[HL05] Section 2.3" begin
     Mod.@polyvar x y
     η = AtomicMeasure([x, y], WeightedDiracMeasure.([[1, 2], [2, 2], [2, 3]], [0.4132, 0.3391, 0.2477]))
     μ = measure(η, [x^4, x^3*y, x^2*y^2, x*y^3, y^4, x^3, x^2*y, x*y^2, y^3, x^2, x*y, y^2, x, y, 1])
     ν = moment_matrix(μ, [1, x, y, x^2, x*y, y^2])
     for lrc in (SVDChol(), ShiftChol(1e-14))
-        atoms = extractatoms(ν, 1e-4, lrc)
-        @test atoms !== nothing
-        @test atoms ≈ η
+        for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
+            atoms = extractatoms(ν, 1e-4, lrc, solver)
+            @test atoms !== nothing
+            @test atoms ≈ η
+        end
     end
 end
 
@@ -68,9 +78,11 @@ end
                 [x^4, x^3*y, x^2*y^2, x*y^3, y^4, x^3, x^2*y, x*y^2, y^3, x^2, x*y, y^2, x, y, 1])
     ν = moment_matrix(μ, [1, x, y, x^2, x*y, y^2])
     for lrc in (SVDChol(), ShiftChol(1e-16))
-        atoms = extractatoms(ν, 1e-16, lrc)
-        @test atoms !== nothing
-        @test atoms ≈ η
+        for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
+            atoms = extractatoms(ν, 1e-16, lrc, solver)
+            @test atoms !== nothing
+            @test atoms ≈ η
+        end
     end
 end
 
@@ -95,9 +107,11 @@ end
     Mod.@polyvar x[1:2]
     η = AtomicMeasure(x, [WeightedDiracMeasure([1., 0.], 2.53267)])
     ν = moment_matrix([2.53267 -0.0 -5.36283e-19; -0.0 -5.36283e-19 -0.0; -5.36283e-19 -0.0 7.44133e-6], monomials(x, 2))
-    atoms = extractatoms(ν, 1e-5)
-    @test atoms !== nothing
-    @test atoms ≈ η
+    for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
+        atoms = extractatoms(ν, 1e-5, solver)
+        @test atoms !== nothing
+        @test atoms ≈ η
+    end
 end
 
 @testset "[LJP17] Example ?" begin

--- a/test/moment_matrix.jl
+++ b/test/moment_matrix.jl
@@ -1,7 +1,12 @@
 using Test
 
-import HomotopyContinuation
-const HC = HomotopyContinuation
+struct DummySolver <: SemialgebraicSets.AbstractAlgebraicSolver end
+function SemialgebraicSets.solvealgebraicequations(
+    ::SemialgebraicSets.AlgebraicSet,
+    ::DummySolver,
+)
+    error("Dummy solver")
+end
 
 @testset "MomentMatrix" begin
     Mod.@polyvar x y
@@ -37,11 +42,10 @@ const DEFAULT_SOLVER = SemialgebraicSets.defaultalgebraicsolver([1.0x - 1.0x])
     μ = measure(η, [x^4, x^3*y, x^2*y^2, x*y^3, y^4, x^3, x^2*y, x*y^2, y^3, x^2, x*y, y^2, x, y, 1])
     ν = moment_matrix(μ, [1, x, y, x^2, x*y, y^2])
     for lrc in (SVDChol(), ShiftChol(1e-14))
-        for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
-            atoms = extractatoms(ν, 1e-4, lrc, solver)
-            @test atoms !== nothing
-            @test atoms ≈ η
-        end
+        @test_throws ErrorException("Dummy solver") extractatoms(ν, 1e-4, lrc, DummySolver())
+        atoms = extractatoms(ν, 1e-4, lrc, DEFAULT_SOLVER)
+        @test atoms !== nothing
+        @test atoms ≈ η
     end
 end
 
@@ -78,11 +82,9 @@ end
                 [x^4, x^3*y, x^2*y^2, x*y^3, y^4, x^3, x^2*y, x*y^2, y^3, x^2, x*y, y^2, x, y, 1])
     ν = moment_matrix(μ, [1, x, y, x^2, x*y, y^2])
     for lrc in (SVDChol(), ShiftChol(1e-16))
-        for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
-            atoms = extractatoms(ν, 1e-16, lrc, solver)
-            @test atoms !== nothing
-            @test atoms ≈ η
-        end
+        atoms = extractatoms(ν, 1e-16, lrc)
+        @test atoms !== nothing
+        @test atoms ≈ η
     end
 end
 
@@ -107,11 +109,10 @@ end
     Mod.@polyvar x[1:2]
     η = AtomicMeasure(x, [WeightedDiracMeasure([1., 0.], 2.53267)])
     ν = moment_matrix([2.53267 -0.0 -5.36283e-19; -0.0 -5.36283e-19 -0.0; -5.36283e-19 -0.0 7.44133e-6], monomials(x, 2))
-    for solver in (HC.SemialgebraicSetsHCSolver(; compile = false), DEFAULT_SOLVER)
-        atoms = extractatoms(ν, 1e-5, solver)
-        @test atoms !== nothing
-        @test atoms ≈ η
-    end
+    @test_throws ErrorException("Dummy solver") extractatoms(ν, 1e-5, DummySolver())
+    atoms = extractatoms(ν, 1e-5, DEFAULT_SOLVER)
+    @test atoms !== nothing
+    @test atoms ≈ η
 end
 
 @testset "[LJP17] Example ?" begin


### PR DESCRIPTION
Support for using homotopy continuation using the SemialgebraicSets interface was added in JuliaHomotopyContinuation/HomotopyContinuation.jl#445
This PR passes the remaining arguments to the algebraic set constructor to allow for instance to choose a different solver than the default one.
It also updates the docstring recommending to use HomotopyContinuation ove the default with an example on how to use it.
cc @saschatimme