### PR TITLE
Add MomentMatrixWeightSolver option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,8 @@ julia = "1"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DynamicPolynomials", "Test"]
+test = ["DynamicPolynomials", "Random", "Test"]

--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -45,3 +45,13 @@ ShiftChol
 SVDChol
 MultivariateMoments.lowrankchol
 ```
+
+Once the center of the atoms are determined, a linear system is solved to determine
+the weights corresponding to each dirac.
+By default, [`MomentMatrixWeightSolver`](@ref) is used by [`extractatoms`](@ref) so that if there are small differences between moment values corresponding to the same monomial in the matrix
+(which can happen if these moments were computed numerically by a semidefinite proramming solvers, e.g., with [SumOfSquares](https://github.com/jump-dev/SumOfSquares.jl)),
+the linear system handles that automatically.
+```@docs
+MomentMatrixWeightSolver
+MomentVectorWeightSolver
+```

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -203,7 +203,7 @@ end
     end
 
 Given a moment matrix `ν` and the atom centers, first convert the moment matrix
-to a vector of moments, using [`measure(ν; rtol=rtol, atol=atol)`](@ref `measure`)
+to a vector of moments, using [`measure(ν; rtol=rtol, atol=atol)`](@ref measure)
 and then determine the weights by solving a linear system over the monomials obtained.
 
 If the moment values corresponding to the same monomials can have small differences,

--- a/src/extract.jl
+++ b/src/extract.jl
@@ -169,16 +169,6 @@ end
 
 # Determines weight
 
-function solve_weight(ν::MomentMatrix{T}, centers, solver::MomentVectorWeightSolver) where {T}
-    μ = measure(ν; rtol=solver.rtol, atol=solver.atol)
-    vars = variables(μ)
-    A = Matrix{T}(undef, length(μ.x), length(centers))
-    for i in eachindex(centers)
-        A[:, i] = dirac(μ.x, vars => centers[i]).a
-    end
-    return A \ μ.a
-end
-
 """
     struct MomentMatrixWeightSolver
         rtol::T
@@ -239,6 +229,16 @@ function MomentVectorWeightSolver(; rtol=nothing, atol=nothing)
     else
         return MomentVectorWeightSolver{typeof(atol)}(; atol=atol)
     end
+end
+
+function solve_weight(ν::MomentMatrix{T}, centers, solver::MomentVectorWeightSolver) where {T}
+    μ = measure(ν; rtol=solver.rtol, atol=solver.atol)
+    vars = variables(μ)
+    A = Matrix{T}(undef, length(μ.x), length(centers))
+    for i in eachindex(centers)
+        A[:, i] = dirac(μ.x, vars => centers[i]).a
+    end
+    return A \ μ.a
 end
 
 """

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -11,7 +11,7 @@ struct Measure{T, MT <: AbstractMonomial, MVT <: AbstractVector{MT}} <: Abstract
         new(a, x)
     end
 end
-function Measure(a::AbstractVector{T}, x::AbstractVector{TT}) where {T, TT <: AbstractTermLike}
+function Measure(a::AbstractVector{T}, x::AbstractVector{TT}; kws...) where {T, TT <: AbstractTermLike}
     # cannot use `monovec(a, x)` as it would sum the entries
     # corresponding to the same monomial.
     if length(a) != length(x)
@@ -24,7 +24,7 @@ function Measure(a::AbstractVector{T}, x::AbstractVector{TT}) where {T, TT <: Ab
         for i in eachindex(x)
             j = rev[x[i]]
             if i != σ[j]
-                if !isapprox(b[j], a[i])
+                if !isapprox(b[j], a[i]; kws...)
                     error("The monomial `$(x[i])` is occurs twice with different values: `$(a[i])` and `$(b[j])`")
                 end
             end
@@ -34,11 +34,14 @@ function Measure(a::AbstractVector{T}, x::AbstractVector{TT}) where {T, TT <: Ab
 end
 
 """
-    measure(a, X::AbstractVector{<:AbstractMonomial})
+    measure(a::AbstractVector{T}, X::AbstractVector{<:AbstractMonomial}; rtol=Base.rtoldefault(T), atol=zero(T))
 
 Creates a measure with moments `moment(a[i], X[i])` for each `i`.
+An error is thrown if there exists `i` and `j` such that `X[i] == X[j]` but
+`!isapprox(a[i], a[j]; rtol=rtol, atol=atol)`.
 """
-measure(a, X) = Measure(a, X)
+measure(a, X; kws...) = Measure(a, X; kws...)
+measure(a, basis::MB.MonomialBasis; kws...) = measure(a, basis.monomials; kws...)
 
 """
     variables(μ::AbstractMeasureLike)

--- a/src/moment_matrix.jl
+++ b/src/moment_matrix.jl
@@ -66,10 +66,15 @@ moment_matrix(Q::AbstractMatrix, monos) = MomentMatrix(Q, monos)
 
 getmat(μ::MomentMatrix) = Matrix(μ.Q)
 
-function measure(ν::MomentMatrix{T, <:MB.MonomialBasis, SymMatrix{T}}) where T
-    n = length(ν.basis)
+function vectorized_basis(ν::MomentMatrix{T,<:MB.MonomialBasis}) where {T}
     monos = ν.basis.monomials
-    measure(ν.Q.Q, [monos[i] * monos[j] for i in 1:n for j in 1:i])
+    n = length(monos)
+    return MB.MonomialBasis([monos[i] * monos[j] for i in 1:n for j in 1:i])
+end
+
+function measure(ν::MomentMatrix; kws...) where T
+    n = length(ν.basis)
+    measure(ν.Q.Q, vectorized_basis(ν); kws...)
 end
 
 struct SparseMomentMatrix{T, B <: MB.AbstractPolynomialBasis, MT} <: AbstractMomentMatrix{T, B}


### PR DESCRIPTION
In https://github.com/JuliaAlgebra/MultivariateMoments.jl/pull/26, when converting a `MomentMatrix` to a `Measure`, an error is thrown if the moments are not approximately the same.
This conversion is here:
https://github.com/JuliaAlgebra/MultivariateMoments.jl/blob/0eb511d841966fcc8fa68a2ec8a3efcece86d515/src/extract.jl#L200
This is making https://github.com/jump-dev/SumOfSquares.jl/pull/224 fail because the moment matrix given by an SDP solver may have differences higher than `Base.rtoldefault(Float64)`. For this reason, the default option is to not convert and solve the linear system on the moment matrix directly. The old way is still available via the `MomentVectorWeightSolver` but is not the default anymore since it would be tricky to get default tolerances, it's best to let the user choose this explicitly so that it's clearer that he should set tolerances.