### PR TITLE
Raise compat for Colors v0.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StarAlgebras = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
 
 [compat]
-Colors = "0.12"
+Colors = "0.12 - 0.13"
 CommonSolve = "0.2"
 MultivariateBases = "0.2"
 MultivariatePolynomials = "0.5"


### PR DESCRIPTION
When testing locally, I get
```julia
ERROR: LoadError: UndefVarError: `SubBasis` not defined in `MultivariateBases`
```
But this also happens on `master`. Not sure why it does not happen here.